### PR TITLE
New Notebook for Cluster Runtime Version

### DIFF
--- a/cluster_runtime_version_listing/Cluster Runtime Versions.py
+++ b/cluster_runtime_version_listing/Cluster Runtime Versions.py
@@ -1,0 +1,43 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC ##### URL to manually create runtime version string
+# MAGIC https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/#--runtime-version-strings
+
+# COMMAND ----------
+
+import requests
+import json
+from pyspark.sql.functions import udf, col, explode
+from pyspark.sql.types import StructType, StructField, IntegerType, StringType, ArrayType
+from pyspark.sql import Row
+
+def executeRestApi(verb, url, headers, body):
+  res = None
+  # Make API request, get response object back
+  try:
+    if verb == "get":
+      res = requests.get(url, data=body, headers=headers)
+    else:
+      res = requests.post(url, data=body, headers=headers)
+  except Exception as e:
+    return e
+  if res != None and res.status_code == 200:
+    return res.text
+  return None
+
+
+
+# COMMAND ----------
+
+# Utilized Key Vault as a Secret Scope to save off access token and urls
+databricksURL = dbutils.secrets.get('key-vault-secret','secret-bricks-url')
+AccessToken = dbutils.secrets.get('key-vault-secret','secret-bricks-accesstoken')
+headers = {
+      'content-type': "application/json",
+      'Authorization': f'Bearer {AccessToken}'
+  }
+
+x = executeRestApi ('get',f'https://{databricksURL}/api/2.0/clusters/spark-versions',headers,None)
+df = spark.read.json(sc.parallelize([x]))
+display(df.select(explode("versions").alias("versions")).orderBy("versions.key"))
+

--- a/cluster_runtime_version_listing/README.md
+++ b/cluster_runtime_version_listing/README.md
@@ -1,0 +1,17 @@
+## Purpose
+This notebook is attended to help find what versions of Databricks Runtime is available.  
+The output of the API call returns the value for Databricks Runtime to be used to create a cluster.
+A good use case is with Azure Data Factory to start a Job Cluster with a particular Runtime value.ickly to enable better performance when the reports do start.
+
+##### NOTE: 
+
+A [Databricks Personal Access Token](https://docs.databricks.com/dev-tools/api/latest/authentication.html#:~:text=Generate%20a%20personal%20access%20token,-This%20section%20describes&text=Settings%20in%20the%20lower%20left,the%20Generate%20New%20Token%20button.) is required to connect to the sql endpoint from this notebook.
+
+
+##### NOTE2b: 
+
+Knowing the URL of your databricks instance is needed as well.
+
+##### NOTE2b: 
+
+We strongly suggest keeping your access token and databricks instance URL in an [Azure Keyvault backed secret scope](https://docs.microsoft.com/en-us/azure/databricks/security/secrets/secret-scopes).


### PR DESCRIPTION
This notebook is attended to help find what versions of Databricks Runtime is available.
The output of the API call returns the value for Databricks Runtime to be used to create a cluster.
A good use case is with Azure Data Factory to start a Job Cluster with a particular Runtime value.ickly to enable better performance when the reports do start.